### PR TITLE
Update options.py

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1707,7 +1707,8 @@ class UnhosedConfigParser(ConfigParser.RawConfigParser):
                 raise
             else:
                 optval = default
-
+        if isinstance(optval, unicode): 
+            optval = str(optval)  #  在使用configparser模块，对读取配置文件内容类型为 unicode的情况做处理
         if do_expand and isinstance(optval, basestring):
             combined_expansions = dict(
                 list(self.expansions.items()) + list(expansions.items()))


### PR DESCRIPTION
File "/usr/lib/python2.6/site-packages/supervisor-4.0.0.dev0-py2.6.egg/supervisor/options.py", line 1457, in stat
    return os.stat(filename)
TypeError: stat() argument 1 must be encoded string without NULL bytes, not str
